### PR TITLE
Expanded mDjiController functionality for Phantom 2 controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 mDjiController
 ===============
  - Connect your DJI Remote Controller to your PC and use it to play simulators.
+ - Currently confirmed working controllers: DJI Phantom 2
 -----------------------------------------------------------------------------
 
 

--- a/src/Joystick.cpp
+++ b/src/Joystick.cpp
@@ -48,32 +48,75 @@ Joystick::Joystick(int id, int logging)
 	}
 }
 
-void Joystick::update(int l_hor, int l_ver, int r_hor, int r_ver, int btn)
+void Joystick::update(int l_hor, int l_ver, int r_hor, int r_ver, int lever_left, int lever_right, int camera)
 {
 	// Values must be between 0x0 and 0x8000
-	// The values from the controller are between -1000 and 1000,
-	// so we just make them be 0 to 2000, and then calibrate the controller in the simulator
+	// The values from the controller are between -1000 and 1000, so we just scale them between 0 and 16000 (maximum range in vJoyMonitor)	
 	l_hor += 1000;
 	l_ver += 1000;
 	r_hor += 1000;
 	r_ver += 1000;
+	camera -= 1000;
 
-	if (btn == 780) {
-		button = true;
+	l_hor *= 16;
+	l_ver *= 16;
+	r_hor *= 16;
+	r_ver *= 16;
+	camera *= -16; // negative multiplication to make the value feel natural (left = negative | right = positive)
+
+	// Read values from left lever
+	// -780 = 'OFF' position | 0 = 'CL' position | 780 = 'HL' position
+	if (lever_left == -780) {
+		button_1 = true;
+		button_2 = false;
+		button_3 = false;
 	}
-	else if (btn == -780) {
-		button = false;
+	else if (lever_left == 780) {
+		button_1 = false;
+		button_2 = false;
+		button_3 = true;
 	} // else remain as before, sometimes this value is a bit weird
+	else if (lever_left == 0) {
+		button_1 = false;
+		button_2 = true;
+		button_3 = false;
+	}
+
+	// Read values from right lever
+	// -780 = 'GPS' position | 0 = 'ATTI' position | 780 = 'ATTI' position
+	if (lever_right == -780) {
+		button_4 = true;
+		button_5 = false;
+		button_6 = false;
+	}
+	else if (lever_right == 780) {
+		button_4 = false;
+		button_5 = false;
+		button_6 = true;
+	} // else remain as before, sometimes this value is a bit weird
+	else {
+		button_4 = false;
+		button_5 = true;
+		button_6 = false;
+	}
 
 	if (log)
-		printf("L vert: %-5d | L hori: %-5d | R vert: %-5d | R hori: %-5d | btn: %-d\n", l_ver, l_hor, r_ver, r_hor, button);
+		printf("L vert: %-5d | L hori: %-5d | R vert: %-5d | R hori: %-5d | btn1: %-d | btn2: %-d | btn3: %-d | btn4: %-d | btn5: %-d | btn6: %-d | camera: %-d\n", l_ver, l_hor, r_ver, r_hor, button_1, button_2, button_3, button_4, button_5, button_6, camera);
 
+	// Send stick values to vJoy
 	SetAxis(l_hor, interfaceId, HID_USAGE_X);
 	SetAxis(l_ver, interfaceId, HID_USAGE_Y);
 	SetAxis(r_hor, interfaceId, HID_USAGE_Z);
 	SetAxis(r_ver, interfaceId, HID_USAGE_RX);
+	SetAxis(camera, interfaceId, HID_USAGE_RY);
 	
-	SetBtn(button, interfaceId, 1);
+	// Send button values to vJoy
+	SetBtn(button_1, interfaceId, 1);
+	SetBtn(button_2, interfaceId, 2);
+	SetBtn(button_3, interfaceId, 3);
+	SetBtn(button_4, interfaceId, 4);
+	SetBtn(button_5, interfaceId, 5);
+	SetBtn(button_6, interfaceId, 6);
 }
 
 Joystick::~Joystick()

--- a/src/Joystick.h
+++ b/src/Joystick.h
@@ -13,13 +13,13 @@
 class Joystick
 {
 private:
-	bool button;
+	bool button_1, button_2, button_3, button_4, button_5, button_6;
 	bool connected;
 	unsigned int interfaceId;
 	bool log = false;
 public:
 	Joystick(int interfaceId, int logging);
 	~Joystick();
-	void update(int l_hor, int l_ver, int r_hor, int r_ver, int btn);
+	void update(int l_hor, int l_ver, int r_hor, int r_ver, int toggle_left, int toggle_right, int camera);
 	bool isConnected() { return connected;  }
 };

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -54,17 +54,20 @@ void run(char* portName, int stickId, int logging) {
 		s.WriteData(pingData, 34); // write this once in a while, otherwise it stops sending? :O
 		readResult = s.ReadData(incomingData, dataLength);
 
-		if (readResult == 76 && incomingData[0] == 0x55) { // proably positioning data
+		if (readResult == 76 && incomingData[0] == 0x55) { // probably positioning data
 			short left_vertical = littleEndiansToShort(incomingData[39], incomingData[40]);
 			short left_horizontal = littleEndiansToShort(incomingData[43], incomingData[44]);
 
 			short right_horizontal = littleEndiansToShort(incomingData[31], incomingData[32]);
 			short right_vertical = littleEndiansToShort(incomingData[35], incomingData[36]);
 
+			short left_lever = littleEndiansToShort(incomingData[47], incomingData[48]);
 			short right_lever = littleEndiansToShort(incomingData[51], incomingData[52]);
 
+			short camera = littleEndiansToShort(incomingData[55], incomingData[56]);
+
 			// update our virtual joystick
-			j.update(left_horizontal, left_vertical, right_horizontal, right_vertical, right_lever);
+			j.update(left_horizontal, left_vertical, right_horizontal, right_vertical, left_lever, right_lever, camera);
 		}
 
 
@@ -95,7 +98,7 @@ int main() {
 	sprintf_s(port, "COM%d", portNr);
 
 
-	printf("Select vJoy configration (default \"1\"): ");
+	printf("Select vJoy configuration (default \"1\"): ");
 	std::getline(std::cin, in);
 	stickId = atoi(in.c_str());
 

--- a/src/Serial.cpp
+++ b/src/Serial.cpp
@@ -10,7 +10,7 @@ Serial::Serial(char *portName)
 	//We're not yet connected
 	this->connected = false;
 
-	//Try to connect to the given port throuh CreateFile
+	//Try to connect to the given port through CreateFile
 	this->hSerial = CreateFile(portName,
 		GENERIC_READ | GENERIC_WRITE,
 		0,
@@ -19,13 +19,13 @@ Serial::Serial(char *portName)
 		FILE_ATTRIBUTE_NORMAL,
 		NULL);
 
-	//Check if the connection was successfull
+	//Check if the connection was successful
 	if (this->hSerial == INVALID_HANDLE_VALUE)
 	{
 		//If not success full display an Error
 		if (GetLastError() == ERROR_FILE_NOT_FOUND){
 
-			//Print Error if neccessary
+			//Print Error if necessary
 			printf("ERROR: Handle was not attached. Reason: %s not available.\n", portName);
 
 		}
@@ -48,7 +48,7 @@ Serial::Serial(char *portName)
 		}
 		else
 		{
-			//Define serial connection parameters for the arduino board
+			//Define serial connection parameters for the Arduino board
 			dcbSerialParams.BaudRate = 115200;
 			dcbSerialParams.ByteSize = 8;
 			dcbSerialParams.StopBits = ONESTOPBIT;


### PR DESCRIPTION
I have finally found time to upgrade the _mDjiController_ functionality for the Phantom 2 controller. I needed all the controls available on the Phantom 2 controller to be able to fly a drone in the [AirSim](https://github.com/Microsoft/AirSim) simulation (to be able to switch PX4 flight modes for instance).

- mDdjiController now supports both levers completely, offering a total of 6 buttons (one for every lever position).

- The camera scroll wheel is also implemented and mapped to _HID_USAGE_RY_. 

I have tested and verified the implementation.